### PR TITLE
Update Socket.io Swift client

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nativescript-socket.io",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Socket.io implementation in NativeScript",
   "main": "socket",
   "typings": "socket.d.ts",

--- a/platforms/ios/Podfile
+++ b/platforms/ios/Podfile
@@ -1,1 +1,1 @@
-pod 'Socket.IO-Client-Swift', '~> 8.1.1'
+pod 'Socket.IO-Client-Swift', '~> 8.3.1'


### PR DESCRIPTION
Building with the latest Xcode 8.3 (which comes with Swift 3.1) requires version 8.3.1 or newer of the Socket.io Swift client. I've updated the dependency in the podfile.